### PR TITLE
Tighten article link extraction and add URL-based prioritization for spider

### DIFF
--- a/datascience/quant-data-sys/src/api/dependencies.py
+++ b/datascience/quant-data-sys/src/api/dependencies.py
@@ -6,6 +6,7 @@ from src.services.scraper_service import ScraperService
 from src.services.spider_service import SpiderService
 from src.core.filters.filter_service import LinkFilterService
 from src.core.filters.pattern_filter import PatternLinkFilter
+from src.core.relevance.article_priority import ArticlePriorityPolicy
 from src.dto.config_dto import AppConfigDTO
 
 _config: AppConfigDTO = None
@@ -60,6 +61,28 @@ def get_filter_service() -> LinkFilterService:
         r'/search\?',
         r'\.(pdf|doc|docx|xls|xlsx|zip|rar)$',
         r'#',
+        r'/sports?/',
+        r'/sport/',
+        r'/cricket/',
+        r'/football/',
+        r'/tennis/',
+        r'/basketball/',
+        r'/olympics?/',
+        r'/entertainment/',
+        r'/bollywood/',
+        r'/hollywood/',
+        r'/celebrity/',
+        r'/movie/',
+        r'/music/',
+        r'/tv/',
+        r'/lifestyle/',
+        r'/fashion/',
+        r'/beauty/',
+        r'/travel/',
+        r'/food/',
+        r'/recipe/',
+        r'/horoscope/',
+        r'/astrology/',
     ]
     
     default_content_patterns = [
@@ -77,12 +100,18 @@ def get_filter_service() -> LinkFilterService:
     return filter_service
 
 
+def get_priority_policy() -> ArticlePriorityPolicy:
+    """Get default article priority policy."""
+    return ArticlePriorityPolicy()
+
+
 def get_spider_service() -> SpiderService:
     """Get spider service - uses session factory"""
     config = get_config()
     scraper_service = get_scraper_service()
     db_manager = get_db_manager()
     filter_service = get_filter_service()
+    priority_policy = get_priority_policy()
     
     if db_manager.session_factory is None:
         raise RuntimeError("Database not initialized")
@@ -91,6 +120,7 @@ def get_spider_service() -> SpiderService:
         scraper_service,
         db_manager.session_factory,
         filter_service=filter_service,
+        priority_policy=priority_policy,
         max_workers=3,
         max_queue_size=876,
         cooldown_seconds=config.retry.cooldown_seconds

--- a/datascience/quant-data-sys/src/core/relevance/__init__.py
+++ b/datascience/quant-data-sys/src/core/relevance/__init__.py
@@ -1,0 +1,1 @@
+"""Relevance and priority helpers for news scraping."""

--- a/datascience/quant-data-sys/src/core/relevance/article_priority.py
+++ b/datascience/quant-data-sys/src/core/relevance/article_priority.py
@@ -1,0 +1,87 @@
+import re
+from typing import Iterable, List, Optional
+
+
+DEFAULT_EXCLUDE_URL_PATTERNS = [
+    r"/sports?/",
+    r"/sport/",
+    r"/cricket/",
+    r"/football/",
+    r"/tennis/",
+    r"/basketball/",
+    r"/olympics?/",
+    r"/entertainment/",
+    r"/bollywood/",
+    r"/hollywood/",
+    r"/celebrity/",
+    r"/movie/",
+    r"/music/",
+    r"/tv/",
+    r"/lifestyle/",
+    r"/fashion/",
+    r"/beauty/",
+    r"/travel/",
+    r"/food/",
+    r"/recipe/",
+    r"/horoscope/",
+    r"/astrology/",
+]
+
+DEFAULT_HIGH_PRIORITY_PATTERNS = [
+    r"/business/",
+    r"/markets?/",
+    r"/economy/",
+    r"/economics/",
+    r"/finance/",
+    r"/stocks?/",
+    r"/companies?/",
+    r"/industry/",
+    r"/bank(s|ing)/",
+    r"/commodities?/",
+    r"/ipo/",
+    r"/earnings?/",
+    r"/results?/",
+    r"/policy/",
+    r"/regulator/",
+    r"/rbi/",
+    r"/sebi/",
+    r"/government/",
+]
+
+DEFAULT_LOW_PRIORITY_PATTERNS = [
+    r"/opinion/",
+    r"/editorial/",
+    r"/feature/",
+    r"/analysis/",
+    r"/interview/",
+]
+
+
+class ArticlePriorityPolicy:
+    """Heuristic URL-based priority policy for news articles."""
+
+    def __init__(
+        self,
+        exclude_url_patterns: Optional[Iterable[str]] = None,
+        high_priority_patterns: Optional[Iterable[str]] = None,
+        low_priority_patterns: Optional[Iterable[str]] = None,
+        case_sensitive: bool = False
+    ):
+        flags = 0 if case_sensitive else re.IGNORECASE
+        exclude_patterns = list(exclude_url_patterns or DEFAULT_EXCLUDE_URL_PATTERNS)
+        high_patterns = list(high_priority_patterns or DEFAULT_HIGH_PRIORITY_PATTERNS)
+        low_patterns = list(low_priority_patterns or DEFAULT_LOW_PRIORITY_PATTERNS)
+
+        self._exclude_patterns = [re.compile(p, flags) for p in exclude_patterns]
+        self._high_patterns = [re.compile(p, flags) for p in high_patterns]
+        self._low_patterns = [re.compile(p, flags) for p in low_patterns]
+
+    def should_exclude_url(self, url: str) -> bool:
+        return any(pattern.search(url) for pattern in self._exclude_patterns)
+
+    def get_priority(self, url: str) -> int:
+        if any(pattern.search(url) for pattern in self._high_patterns):
+            return -10
+        if any(pattern.search(url) for pattern in self._low_patterns):
+            return 10
+        return 0

--- a/datascience/quant-data-sys/src/plugins/scrapers/generic.py
+++ b/datascience/quant-data-sys/src/plugins/scrapers/generic.py
@@ -35,9 +35,13 @@ class GenericScraper(BaseScraper):
         
         all_resolved_links = await cleaner.extract_all_resolved_links(base_url=self.url, min_length=25)
         logger.debug(f"[GENERIC SCRAPER] Extracted {len(all_resolved_links)} resolved links (length > 25)")
-        
-        article_links = article_links.union(all_resolved_links)
-        logger.debug(f"[GENERIC SCRAPER] Total article links after merging: {len(article_links)}")
+
+        filtered_links = await cleaner.filter_probable_article_links(
+            all_resolved_links,
+            base_url=self.url
+        )
+        article_links = article_links.union(filtered_links)
+        logger.debug(f"[GENERIC SCRAPER] Total article links after filtering: {len(article_links)}")
         
         cleaner = await self._run_cleaning_pipeline(cleaner)
         cleaned_html = await cleaner.get_html()


### PR DESCRIPTION
### Motivation
- Reduce noisy crawl targets and prioritize business/market articles so the spider focuses on relevant news (avoid sports/entertainment noise). 
- Provide a simple, configurable URL-based policy to decide skip vs high/low priority before enqueuing links.

### Description
- Add `HtmlCleaner.filter_probable_article_links(...)` to heuristically keep probable article URLs (ID-based, dated paths, and improved slug heuristics) and log filtering results; updated `HtmlCleaner` to expose this helper. 
- Use the new filter in `plugins/scrapers/generic.py` so resolved links are narrowed to probable article links before union with other link detectors. 
- Introduce `core/relevance/article_priority.py` with `ArticlePriorityPolicy` that defines exclusion, high-priority and low-priority regex patterns for URLs and exposes `should_exclude_url` and `get_priority`. 
- Wire the priority policy into the spider: `services/spider_service.py` now consults the policy to skip excluded URLs and set/enqueue link priorities, and `api/dependencies.py` provides a default `ArticlePriorityPolicy` and expands default pattern filters to exclude obvious non-news sections (sports/entertainment/etc.).

### Testing
- No automated tests were executed as part of this change (`unit`/`integration` tests were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698709f3815883328dcbd423f18cd0c4)